### PR TITLE
Add port selection shell command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-PORT := /dev/tty.usbmodem144401
+PORT := $(shell (ls /dev/*modem* || ls /dev/*ACM*) | head -n 1)
 
 build:
 	cargo build --release


### PR DESCRIPTION
Select the port to flash the code to inside `/dev` automatically. This is somewhat basic logic, that doesn't try to check if the device is in fact an Arduino Nano 33 IoT or anything, but it should be more than good enough for now.

Some better error handling when the device isn't showing up as a serial port would be nice.